### PR TITLE
renames status-list-manager-git to credential-status-manager-git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# status-list-manager-git Changelog
+# credential-status-manager-git Changelog
 
 ## 1.0.0 - 2023-xx-xx
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# status-list-manager-git
+# credential-status-manager-git
 
 A Typescript library for managing the status of [Verifiable Credentials](https://www.w3.org/TR/vc-data-model) in Git using [Status List 2021](https://w3c-ccg.github.io/vc-status-list-2021)
 
-[![Build status](https://img.shields.io/github/actions/workflow/status/digitalcredentials/status-list-manager-git/main.yml?branch=main)](https://github.com/digitalcredentials/status-list-manager-git/actions?query=workflow%3A%22Node.js+CI%22)
-[![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/status-list-manager-git.svg)](https://npm.im/@digitalcredentials/status-list-manager-git)
+[![Build status](https://img.shields.io/github/actions/workflow/status/digitalcredentials/credential-status-manager-git/main.yml?branch=main)](https://github.com/digitalcredentials/credential-status-manager-git/actions?query=workflow%3A%22Node.js+CI%22)
+[![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/credential-status-manager-git.svg)](https://npm.im/@digitalcredentials/credential-status-manager-git)
 
 ## Table of Contents
 
@@ -37,7 +37,7 @@ Credentials are dynamic artifacts with a robust lifecycle that goes well beyond 
 To install via NPM:
 
 ```
-npm install @digitalcredentials/status-list-manager-git
+npm install @digitalcredentials/credential-status-manager-git
 ```
 
 ### Development
@@ -45,8 +45,8 @@ npm install @digitalcredentials/status-list-manager-git
 To install locally (for development):
 
 ```
-git clone https://github.com/digitalcredentials/status-list-manager-git.git
-cd status-list-manager-git
+git clone https://github.com/digitalcredentials/credential-status-manager-git.git
+cd credential-status-manager-git
 npm install
 ```
 
@@ -75,7 +75,7 @@ The `createStatusManager` function is the only exported pure function of this li
 Here is a sample call to `createStatusManager`:
 
 ```ts
-import { createStatusManager } from '@digitalcredentials/status-list-manager-git';
+import { createStatusManager } from '@digitalcredentials/credential-status-manager-git';
 
 const statusManager = await createStatusManager({
   service: 'github',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@digitalcredentials/status-list-manager-git",
+  "name": "@digitalcredentials/credential-status-manager-git",
   "description": "A Typescript library for managing the status of Verifiable Credentials in Git using Status List 2021",
   "version": "0.0.1",
   "publishConfig": {
@@ -25,10 +25,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/digitalcredentials/status-list-manager-git"
+    "url": "https://github.com/digitalcredentials/credential-status-manager-git"
   },
-  "homepage": "https://github.com/digitalcredentials/status-list-manager-git",
-  "bugs": "https://github.com/digitalcredentials/status-list-manager-git/issues",
+  "homepage": "https://github.com/digitalcredentials/credential-status-manager-git",
+  "bugs": "https://github.com/digitalcredentials/credential-status-manager-git/issues",
   "scripts": {
     "build": "npm run clear && tsc -d && tsc -p tsconfig.esm.json",
     "build-test": "npm run clear && tsc -d && tsc -p tsconfig.spec.json",


### PR DESCRIPTION
This PR updates all repo references from `status-list-manager-git` to `credential-status-manager-git`.